### PR TITLE
Fix: Implement Dynamic Width for LoadingBar.vue to Accurately Reflect Loading Progress

### DIFF
--- a/components/common/LoadingBar.vue
+++ b/components/common/LoadingBar.vue
@@ -14,6 +14,7 @@
       :style="{
         '--progress-updated': background ? `-${100 - progress}%` : '0%',
         '--color-primary': colors.primary,
+        width: `${progress}%`
       }"
     />
   </div>


### PR DESCRIPTION
Hi there,

I noticed that the .loader-progress-indicator in the LoadingBar. vue component lacks a dynamic width property based on the progress prop.  Adding width: "${progress}%" to the indicator’s style is necessary to ensure it accurately reflects the loading progress.

This addition will improve the user’s perception of the loading process and provide a more engaging visual experience.  Could you please implement this change? Thanks!